### PR TITLE
Made constant private

### DIFF
--- a/lib/distributed-lock-google-cloud-storage/lock.rb
+++ b/lib/distributed-lock-google-cloud-storage/lock.rb
@@ -13,6 +13,7 @@ module DistributedLock
     class Lock
       # @!visibility private
       DEFAULT_INSTANCE_IDENTITY_PREFIX_WITHOUT_PID = SecureRandom.hex(12).freeze
+      private_constant(:DEFAULT_INSTANCE_IDENTITY_PREFIX_WITHOUT_PID)
 
       include Utils
 


### PR DESCRIPTION
Based on the YARD comment, DEFAULT_INSTANCE_IDENTITY_PREFIX_WITHOUT_PID constant was intended to be private.

Feel free to discard, I know this is super minor.